### PR TITLE
Clin 525 remove querybuilder from prescription search

### DIFF
--- a/src/views/screens/search/ContentContainer.tsx
+++ b/src/views/screens/search/ContentContainer.tsx
@@ -62,24 +62,12 @@ const ContentContainer = ({
   return (
     <StackLayout className={styles.containerLayout} vertical>
       <ContentHeader searchResults={searchResults} />
-      <QueryBuilder
-        IconTotal={<InfoCircleFilled className={styles.queryBuilderIcon} />}
-        cacheKey="prescription-repo"
-        className="file-repo__query-builder"
-        currentQuery={filters?.content?.length ? filters : {}}
-        dictionary={dictionary}
-        enableCombine={true}
-        history={history}
-        loading={prescriptions?.loading}
-        total={total}
-      />
-
       <Tabs onChange={(v) => tabs.setCurrentTab(v as TableTabs)} type="card">
         <TabPane
           key={TableTabs.Prescriptions}
           tab={
             <>
-              <IconKit icon={ic_people} />
+              <MedicineBoxFilled />
               {intl.get('screen.patient.tab.prescriptions')}
             </>
           }
@@ -92,7 +80,7 @@ const ContentContainer = ({
           key={TableTabs.Patients}
           tab={
             <>
-              <MedicineBoxFilled />
+              <IconKit icon={ic_people} />
               {intl.get('header.navigation.patient')}
             </>
           }


### PR DESCRIPTION
closes clin-525 clin-526

- Switch les icons patient et prescription
- Retire le 'querybuilder'
- 
<img width="952" alt="Screen Shot 2021-12-06 at 11 04 11 AM" src="https://user-images.githubusercontent.com/98903/144880119-d9c22042-d186-4376-9370-5f5b2f2fb926.png">

